### PR TITLE
Chrome update wrecked relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In abstract/base.html:
 In home.html:
 
     <html base="abstract/base.html">
-        <div id="content" replace="//[@id='content']">
+        <div id="content" replace="//*[@id='content']">
             This div will replace the #content div in base.html.
             <div require="fragments/widget.html"></div>
         </div>
@@ -70,7 +70,7 @@ In home.html:
 In blog.html:
 
     <html base="abstract/base.html">
-        <div id="content" replace="//[@id='content']">
+        <div id="content" replace="//*[@id='content']">
             This is a blog entry!
             <div class="extra-markup">
                 <div require="fragments/widget.html"></div>

--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ And blog.html:
         </body>
     </html>
 
+Base path:
+------------
+
+In the examples above, the "included" files are all children of the working directory in which the "master" file is located.
+
+However you can include files from sibling directories, for example:
+
+    <htm base="../common/base.html">
+
+However, this means that a "base" element will be written to the head of the document which sets the base of all hrefs, stylesheets etc. to ".." relative to the current document.
+
+So basically the "root directory" of the application from which all links and assets are based is determined based on the relationship of the "base document" to the document from which it is included.
+
 The details:
 ------------
 

--- a/docs/install-ext.md
+++ b/docs/install-ext.md
@@ -1,10 +1,9 @@
 # Installing Fragmentify as a Chrome Extension
 
-1. Open the Chrome Extensions window (via the Window menu, or the Wrench menu,
-then under "tools")
-2. Find fragmentify-ext.crx in Finder/Windows Explorer/etc
-3. Drag fragmentify-ext.crx onto the Chrome Extensions window
-4. Tick "Allow access to files URLs" as per the screenshot below
-
-![the installed extension](https://raw.github.com/dgrinton/fragmentify-js/master/docs/installed-ext.png)
-
+1. Once you have cloned or downloaded the repository, rename the directory "fragmentify-ext.crx" to "fragmentify-ext.zip"
+2. Extract this zip file to a folder
+3. Go to chrome://extensions/ in Chrome
+4. Enable 'Developer mode' on the right, if not already enabled
+5. Click 'Load unpacked extension...'
+6. Select the folder where you unzipped the extension
+7. Now your extensions should looke like this: https://drive.google.com/file/d/0B9AW45sR9exFUmRsNnF0Y2pJRHM/view?usp=sharing

--- a/docs/install-ext.md
+++ b/docs/install-ext.md
@@ -1,9 +1,6 @@
 # Installing Fragmentify as a Chrome Extension
 
-1. Once you have cloned or downloaded the repository, rename the directory "fragmentify-ext.crx" to "fragmentify-ext.zip"
-2. Extract this zip file to a folder
-3. Go to chrome://extensions/ in Chrome
-4. Enable 'Developer mode' on the right, if not already enabled
-5. Click 'Load unpacked extension...'
-6. Select the folder where you unzipped the extension
-7. Now your extensions should looke like this: https://drive.google.com/file/d/0B9AW45sR9exFUmRsNnF0Y2pJRHM/view?usp=sharing
+1. Once you have cloned or downloaded the repository, go to chrome://extensions/ in Chrome
+2. Click 'Load unpacked extension...'
+3. Select the folder "fragmentify-ext" within the root directory of the repo
+4. Now your extensions should looke like this: https://drive.google.com/file/d/0B9AW45sR9exFUmRsNnF0Y2pJRHM/view?usp=sharing

--- a/fragmentify-ext/fragmentify.js
+++ b/fragmentify-ext/fragmentify.js
@@ -136,7 +136,7 @@ window.Fragmentify = function(){
             process_action(base_doc,v,parent_path);
         });
         $(doc).find('html').removeAttr('base');
-        $(base_doc).find('head').prepend('<base href="'+super_base_path+'" />');
+//        $(base_doc).find('head').prepend('<base href="'+super_base_path+'" />');
         return base_doc;
     };
 

--- a/fragmentify-ext/fragmentify.js
+++ b/fragmentify-ext/fragmentify.js
@@ -1,5 +1,16 @@
 jQuery.noConflict();
 if(!window.Fragmentify) {
+
+Array.prototype.clean = function(deleteValue) {
+  for (var i = 0; i < this.length; i++) {
+    if (this[i] == deleteValue) {         
+      this.splice(i, 1);
+      i--;
+    }
+  }
+  return this;
+};
+
 window.Fragmentify = function(){
     var $ = jQuery;
     var ran = false;
@@ -22,6 +33,7 @@ window.Fragmentify = function(){
                 alert('how do i shot xpath?');
                 return;
             }
+
             var doc = process(path);
             replace_document(doc);
             setTimeout(function(){
@@ -115,6 +127,7 @@ window.Fragmentify = function(){
     var process_base = function(doc, parent_path){
         var actions = $(doc).find('html > *');
         var base_fn = parent_path+$(doc).find('html').attr('base');
+        var super_base_path = get_super_base_path(parent_path,base_fn);
         var base_doc = process(base_fn);
         actions.each(function(k,v){
             if(v.nodeName == 'head') {
@@ -123,8 +136,25 @@ window.Fragmentify = function(){
             process_action(base_doc,v,parent_path);
         });
         $(doc).find('html').removeAttr('base');
+        $(base_doc).find('head').prepend('<base href="'+super_base_path+'" />');
         return base_doc;
     };
+
+    var get_super_base_path = function(document,base_fn)
+    {
+        base_fn = base_fn.replace(document,"");
+        var split_document = document.trim().split("/").clean("");
+        var split_base_fn  = base_fn.trim().split("/").clean("");
+        
+        for(var i = 0;i < split_base_fn.length;i++)
+        {
+            if(split_base_fn[i] == "..")
+                split_document.pop();
+        }
+        
+        return "/"+split_document.join("/")+"/";
+    };
+
     var process_requires = function(root, path) {
         $(root).find('*').andSelf().filter('[require]').each(function(k,v){
             process_require(v, path);


### PR DESCRIPTION
Hey, I found that some update in Chrome broke the relative paths which used to Just Work(TM).

I couldn't find anywhere in the code where you were actually setting a base path -- it appears that previously chrome just automatically dealt with all the various relative paths ... 

Anyway I added in code to detect what the base path actually is by assuming that the html base file is in a "sibling" directory from where the current document resides.

This isn't as elegant as it was before -- perhaps you have a better solution because before you could just include anything from anywhere and it all just seemed to work.

I have only updated the .js file in fragmentify-ext/ i'm not sure that the others need it.

Let me know what you think!